### PR TITLE
libbun/utils: If O_TMPFILE is defined but fails, use the fallback.

### DIFF
--- a/src/bun_utils.c
+++ b/src/bun_utils.c
@@ -127,16 +127,17 @@ open_real_file(const char *name)
 #if defined(O_TMPFILE)
 	fd = open(final_name, O_TMPFILE | O_CLOEXEC | O_RDWR,
 	    S_IRUSR | S_IWUSR);
-	if (fd < 0)
-		goto error;
-#else
-	fd = open(final_name, O_CREAT | O_CLOEXEC | O_TRUNC | O_RDWR,
-	    S_IRUSR | S_IWUSR);
-	if (fd < 0)
-		goto error;
-	if (unlink(final_name) == -1)
-		goto error;
 #endif /* defined(O_TMPFILE) */
+
+	/* If O_TMPFILE not defined, or defined, but failing. */
+	if (fd < 0) {
+		fd = open(final_name, O_CREAT | O_CLOEXEC | O_TRUNC | O_RDWR,
+		    S_IRUSR | S_IWUSR);
+		if (fd < 0)
+			goto error;
+		if (unlink(final_name) == -1)
+			goto error;
+	}
 
 	free(final_name);
 	return fd;


### PR DESCRIPTION
This is a tiny change. If `O_TMPFILE` is defined, but not supported by the kernel, which is something that we've encountered with a few Android NDK configurations, use the same fallback that we use when `O_TMPFILE` is not defined at all.